### PR TITLE
add methods for add role comment

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,5 +1,6 @@
 = ActsAsCommentableMore
 
+{<img src="https://travis-ci.org/piya23300/acts_as_commentable_more.svg" alt="Build Status" />}[https://travis-ci.org/piya23300/acts_as_commentable_more]
 {<img src="https://gemnasium.com/piya23300/acts_as_commentable_more.svg" alt="Dependency Status" />}[https://gemnasium.com/piya23300/acts_as_commentable_more]
 {<img src="https://coveralls.io/repos/piya23300/acts_as_commentable_more/badge.png" alt="Coverage Status" />}[https://coveralls.io/r/piya23300/acts_as_commentable_more]
 

--- a/lib/commentable_methods.rb
+++ b/lib/commentable_methods.rb
@@ -24,11 +24,21 @@ module Happio
           has_many "#{association_name.to_s}".to_sym,
                    -> { where(role: role.to_s) },
                    has_many_options(role, join_options)
+          define_add_role(association_name)
         end
 
         def has_many_options(role, join_options)
           { :before_add => Proc.new { |x, c| c.role = role.to_s } }.merge(join_options)
         end
+
+        def define_add_role(association_name)
+          class_eval %{
+            def add_#{association_name.to_s.singularize}(attributes = nil)
+              #{association_name.to_s}.create(attributes)
+            end
+          }
+        end
+
       end
 
       module ClassMethods
@@ -39,12 +49,15 @@ module Happio
           default_as = :comments
           default_roles = [default_as.to_s.singularize.to_sym]
 
+          types = types.flatten.compact.map(&:to_sym)
+
           association_options = default_options.merge(options.compact)
-          self.comment_roles = (default_roles + types.flatten.compact.map(&:to_sym)).uniq
+          self.comment_roles = types.present? ? types : default_roles
           association_base_name = (as || default_as).to_s.pluralize
 
           if comment_roles == [default_as.to_s.singularize.to_sym]
-            has_many association_base_name.to_sym, has_many_options(default_roles.first, association_options)
+            has_many association_base_name.to_sym, has_many_options(association_base_name.singularize, association_options)
+            define_add_role(association_base_name)
           else
             comment_roles.each do |role|
               define_role_based_inflection(role, association_base_name, association_options)

--- a/test/dummy/app/models/note_custom_asso_name.rb
+++ b/test/dummy/app/models/note_custom_asso_name.rb
@@ -1,3 +1,3 @@
 class NoteCustomAssoName < ActiveRecord::Base
-  acts_as_commentable types: [:private, :publish], as: :custom_notes
+  acts_as_commentable types: [:private, :publish], as: :custom_comments
 end

--- a/test/dummy/app/models/post_custom_asso_name.rb
+++ b/test/dummy/app/models/post_custom_asso_name.rb
@@ -1,5 +1,5 @@
 class PostCustomAssoName < ActiveRecord::Base
-  acts_as_commentable as: :custom_posts
+  acts_as_commentable as: :custom_comments
 
 end
 

--- a/test/dummy/spec/acts_as_commentable_more_spec.rb
+++ b/test/dummy/spec/acts_as_commentable_more_spec.rb
@@ -147,6 +147,17 @@ RSpec.describe ActsAsCommentableMore do
       expect(publish_note.role).to eq 'publish'
     end
 
+    describe "add_{role}_{as} method for adding comment of role" do
+      it "add_private_comment" do
+        note = create(:note)
+        expect{note.add_private_comment(message: 'new comment')}.to change(Comment, :count).by(1)
+      end
+      it "add_publish_comment" do
+        note = create(:note)
+        expect{note.add_publish_comment(message: 'new comment')}.to change(Comment, :count).by(1)
+      end
+    end
+
     describe "class helper" do
       context "self.find_comments_by_user(user, role: nil)" do
         before do
@@ -202,24 +213,36 @@ RSpec.describe ActsAsCommentableMore do
 
   end
 
-  describe "setting :as to custom association name", ff: true do
-    it "doen't have any roles" do
+  describe "setting :as to custom association name" do
+    it "role= :as.singulize" do
       post_custom = create(:post_custom_asso_name)
-      expect{post_custom.custom_posts}.not_to raise_error
-      expect{post_custom.comments}.to raise_error(NoMethodError)
+      comment = post_custom.add_custom_comment
+      expect(comment.role).to eq 'custom_comment'
+    end
+    it "doen't have any roles", ff: true do
+      post_custom = create(:post_custom_asso_name)
+      expect{post_custom.custom_comments}.not_to raise_error
+      expect{post_custom.add_custom_comment()}.not_to raise_error
 
+      expect{post_custom.comments}.to raise_error(NoMethodError)
+      expect{post_custom.add_comment()}.to raise_error(NoMethodError)
     end
 
     it "has roles" do
       note_custom = create(:note_custom_asso_name)
-      expect{note_custom.all_custom_notes}.not_to raise_error
-      expect{note_custom.private_custom_notes}.not_to raise_error
-      expect{note_custom.publish_custom_notes}.not_to raise_error
+      expect{note_custom.all_custom_comments}.not_to raise_error
+      expect{note_custom.private_custom_comments}.not_to raise_error
+      expect{note_custom.publish_custom_comments}.not_to raise_error
+      expect{note_custom.add_publish_custom_comment()}.not_to raise_error
+      expect{note_custom.add_private_custom_comment()}.not_to raise_error
 
-      expect{note_custom.all_notes}.to raise_error(NoMethodError)
-      expect{note_custom.private_notes}.to raise_error(NoMethodError)
-      expect{note_custom.publish_notes}.to raise_error(NoMethodError)
+      expect{note_custom.all_comments}.to raise_error(NoMethodError)
+      expect{note_custom.private_comments}.to raise_error(NoMethodError)
+      expect{note_custom.publish_comments()}.to raise_error(NoMethodError)
+      expect{note_custom.add_publish_comment()}.to raise_error(NoMethodError)
+      expect{note_custom.add_private_comment()}.to raise_error(NoMethodError)
     end
+
   end
 
 end

--- a/test/dummy/spec/acts_as_commentable_more_spec.rb
+++ b/test/dummy/spec/acts_as_commentable_more_spec.rb
@@ -74,7 +74,9 @@ RSpec.describe ActsAsCommentableMore do
   describe "managed comments with association options(:class_name and :as)" do
     it "add a comment" do
       topic = create(:topic)
-      expect{topic.comments.create(message: 'my message')}.to change(CustomComment, :count).by(1)
+      comment = topic.comments.build(message: 'my message')
+      expect{comment.save}.to change(CustomComment, :count).by(1)
+      expect(comment.role).to eq 'comment'
     end
     it "gets all comment" do
       topics = create_list(:topic, 2)


### PR DESCRIPTION
```
class Post < ActiveRecord::Base
  acts_as_commentable 
end

```

```
post.comments #<ActiveRecord::Associations::CollectionProxy []>
post.add_comment #<Comment>
```

---

```
class Note < ActiveRecord::Base
  acts_as_commentable types: [private: public]
end

```

```
post.private_comments #<ActiveRecord::Associations::CollectionProxy []>
post.add_private_comment #<Comment>
```
